### PR TITLE
Support "-1" in Angle and Epoch codes

### DIFF
--- a/database.py
+++ b/database.py
@@ -546,8 +546,8 @@ class Database:
             obs_time                    DATETIME(6),    /* Exact time of observation */
             time_uncertainty            FLOAT,          /* Observation uncertainty (seconds) */
             time_standard_code          TINYINT,        /* Coded time standard */
-            angle_format_code           CHAR(1),        /* Packed code of angle format */
-            epoch_code                  CHAR(1),        /* Packed code of angle EPOCH format */
+            angle_format_code           TINYINT(4),     /* Packed code of angle format */
+            epoch_code                  TINYINT(4),     /* Packed code of angle EPOCH format */
             epoch                       SMALLINT,       /* Decoded EPOCH year */
             ra                          DOUBLE,         /* right ascension (radians) - derived from az/el by iod.py if not provided */
             declination                 DOUBLE,         /* declination of observation (radians) - 'dec' appears to be namespace collision. derived from az/el by iod.py if not provided */


### PR DESCRIPTION
In response to the error experienced in https://github.com/consensys-space/trusat-orbit/issues/14 adjust the DB schema to allow angle_format_code and epoch_code to support signed values.

The parse_(iod/rde/uk) functions implement a "-1" value in the case where an invalid code was received for Angle Format or Epoch codes, and this helps preserve that traceability.

In order to live-update-the database, the following commands can be used to safely implement the change while preserving previous truncated/corrupted values:

`USE appropriate_database';`
`SELECT COUNT(*) FROM ParsedIOD WHERE epoch_code='-';`
`/* Note/review return value for LIMIT below */`
`SELECT COUNT(*) FROM ParsedIOD WHERE angle_format_code='-';`
`/* Note/review return value for LIMIT below */`
`/* Change "invalid/truncated" "-" values to a currently-valid placeholder value */`
`UPDATE ParsedIOD SET epoch_code=9 WHERE epoch_code='-' LIMIT 431;`
`UPDATE ParsedIOD SET angle_format_code=9 WHERE angle_format_code='-' LIMIT 543;`
`/* Alter table structure from CHAR(1) to TINYINT(4) */`
`ALTER TABLE ParsedIOD CHANGE epoch_code epoch_code TINYINT NULL DEFAULT NULL COMMENT '';`
`ALTER TABLE ParsedIOD CHANGE angle_format_code angle_format_code TINYINT NULL DEFAULT NULL COMMENT '';`
`/* Set the previously truncated "-" values to "-1" per original intent */`
`UPDATE ParsedIOD SET epoch_code=-1 WHERE epoch_code=9 LIMIT 431;`
`UPDATE ParsedIOD SET angle_format_code=-1 WHERE angle_format_code=9 LIMIT 543;`

This change has been implemented on the DEV database and tested to work.