### PR TITLE
Bugfix/decayed objects

### DIFF
--- a/database.py
+++ b/database.py
@@ -322,7 +322,7 @@ class Database:
 
         # Latest TLEs for each object that are not known to be decayed
         self.selectLatestTLEPerObject = """
-            SELECT TLE.line0, TLE.line1, TLE.line2,  TLE.satellite_number, TLE.epoch, SatCat.ops_status_code FROM
+            SELECT TLE.line0, TLE.line1, TLE.line2,  TLE.satellite_number, TLE.epoch FROM
               (SELECT max(epoch) AS epoch, satellite_number
               FROM TLE
               GROUP BY satellite_number) AS latest_tles


### PR DESCRIPTION
* Updates self.selectCatalogQueryPrefix and self.selectLatestTLEPerObject components to exclude known-decayed objects from catalog queries
* Addresses JIRA ticket MVP-629
* Closes issue https://github.com/consensys-space/trusat-backend/issues/84